### PR TITLE
Add minimal Alpine Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.18
+ARG SCW_SD_VERSION=v0.1.0
+ARG SCW_SD_OS=linux
+ARG SCW_SD_ARCH=amd64
+RUN apk add --no-cache ca-certificates curl \
+    && curl -L "https://github.com/sudo-bngz/dedibox-sd/releases/download/${SCW_SD_VERSION}/scw-sd-${SCW_SD_OS}-${SCW_SD_ARCH}" -o /usr/local/bin/scw-sd \
+    && chmod +x /usr/local/bin/scw-sd \
+    && apk del curl
+USER nobody
+ENV ONLINE_API_TOKEN=
+ENTRYPOINT ["/usr/local/bin/scw-sd"]


### PR DESCRIPTION
## Summary
- provide a small Alpine-based Dockerfile for running `scw-sd`

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa18479cc832097c2955869a1b313